### PR TITLE
Do not include COMC-1264 in Gantt charts.

### DIFF
--- a/milestones/gantt.py
+++ b/milestones/gantt.py
@@ -9,7 +9,7 @@ GANTT_MILESTONES = [
     "LDM-503",
     "LSST-1200",
     "T&SC-1100-0900",
-    "COMC-1264",
+#    "COMC-1264",
     "CAMM6995",
     "LSST-1220",
     "T&SC-1150-0600",

--- a/milestones/standalone.py
+++ b/milestones/standalone.py
@@ -12,7 +12,7 @@ GANTT_PREAMBLE = """
 \\documentclass{article}
 \\usepackage[
     paperwidth=30cm,
-    paperheight=22.50cm,  % Manually tweaked to fit chart
+    paperheight=22.00cm,  % Manually tweaked to fit chart
     left=0mm,
     top=0mm,
     bottom=0mm,


### PR DESCRIPTION
As of ME 18-05, this milestone has a baseline date of 2013, which is
unplottable on our current charts.

Mailed Kevin 2018-06-14 to see if he knows what happened. For now, disabling
it.