### PR TITLE
Deprecate MOPS terminology

### DIFF
--- a/data/local.yaml
+++ b/data/local.yaml
@@ -163,8 +163,8 @@ DM-AP-16:
 DM-AP-17:
   aka:
   - MOPS
-  description: "All of the algorithmic components which comprise the Moving Objects\
-    \ Processing System (MOPS), as described in LDM-151 \xA7\xA76.25\u20136.28, are\
+  description: "All of the algorithmic components which comprise the Solar System\
+    \ Processing (SSP) pipeline, as described in LDM-151 \xA7\xA76.25\u20136.28, are\
     \ available for integration into science payloads. These components must provide\
     \ realistic interfaces, data-flows and products, but it is expected that the details\
     \ of the algorithms will undergo continued refinement."


### PR DESCRIPTION
Following LCR-2376 this renames MOPS to Solar System Processing for DM-AP-17.